### PR TITLE
Extend Client

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,29 +10,35 @@ const { promisify } = require("util");
 const readdir = promisify(require("fs").readdir);
 const PersistentCollection = require("djs-collection-persistent");
 
+class GuideBot extends Discord.Client {
+  constructor(options) {
+    super(options);
+
+    // Here we load the config.json file that contains our token and our prefix values.
+    this.config = require("./config.json");
+    // client.config.token contains the bot's token
+    // client.config.prefix contains the message prefix
+
+    // Aliases and commands are put in collections where they can be read from,
+    // catalogued, listed, etc.
+    this.commands = new Discord.Collection();
+    this.aliases = new Discord.Collection();
+
+    // Now we integrate the use of Evie's awesome PersistentCollection module, which
+    // essentially saves a collection to disk. This is great for per-server configs,
+    // and makes things extremely easy for this purpose.
+    this.settings = new PersistentCollection({name: "settings"});
+  }
+}
+
 // This is your client. Some people call it `bot`, some people call it `self`,
 // some might call it `cootchie`. Either way, when you see `client.something`,
 // or `bot.something`, this is what we're refering to. Your client.
-const client = new Discord.Client();
-
-// Here we load the config.json file that contains our token and our prefix values.
-client.config = require("./config.json");
-// client.config.token contains the bot's token
-// client.config.prefix contains the message prefix
+const client = new GuideBot();
 
 // Let's start by getting some useful functions that we'll use throughout
 // the bot, like logs and elevation features.
 require("./modules/functions.js")(client);
-
-// Aliases and commands are put in collections where they can be read from,
-// catalogued, listed, etc.
-client.commands = new Discord.Collection();
-client.aliases = new Discord.Collection();
-
-// Now we integrate the use of Evie's awesome PersistentCollection module, which
-// essentially saves a collection to disk. This is great for per-server configs,
-// and makes things extremely easy for this purpose.
-client.settings = new PersistentCollection({name: "settings"});
 
 // We're doing real fancy node 8 async/await stuff here, and to do that
 // we need to wrap stuff in an anonymous function. It's annoying but it works.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discordjs-command-handler",
-  "version": "1.0.0",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordjs-command-handler",
-  "version": "1.5.1",
+  "version": "1.0.0",
   "description": "An example of a Discord.js Bot Handler. Updated and Maintained by the Idiot's Guide Community",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordjs-command-handler",
-  "version": "1.0.0",
+  "version": "1.5.2",
   "description": "An example of a Discord.js Bot Handler. Updated and Maintained by the Idiot's Guide Community",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To reduce bloat from the client, I propose we extend the client class with our own, then append everything to that leaving the original Discord.Client bloat free.