### PR TITLE
Tweaks to Settings to use "merged" settings instead of all-or-nothing

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -9,9 +9,6 @@ help command, its extended help is shown.
 exports.run = (client, message, args, level) => {
   // If no specific command is called, show all filtered commands.
   if (!args[0]) {
-    // Load guild settings (for prefixes and eventually per-guild tweaks)
-    const settings = client.getGuildSettings(message);
-
     // Filter all commands by which are available for the user's level, using the <Collection>.filter() method.
     const myCommands = message.guild ? client.commands.filter(cmd => client.levelCache[cmd.conf.permLevel] <= level) : client.commands.filter(cmd => client.levelCache[cmd.conf.permLevel] <= level &&  cmd.conf.guildOnly !== true);
 
@@ -21,7 +18,7 @@ exports.run = (client, message, args, level) => {
     const longest = commandNames.reduce((long, str) => Math.max(long, str.length), 0);
 
     let currentCategory = "";
-    let output = `= Command List =\n\n[Use ${settings.prefix}help <commandname> for details]\n`;
+    let output = `= Command List =\n\n[Use ${message.settings.prefix}help <commandname> for details]\n`;
     const sorted = myCommands.array().sort((p, c) => p.help.category > c.help.category ? 1 :  p.help.name > c.help.name && p.help.category === c.help.category ? 1 : -1 );
     sorted.forEach( c => {
       const cat = c.help.category.toProperCase();
@@ -29,7 +26,7 @@ exports.run = (client, message, args, level) => {
         output += `\u200b\n== ${cat} ==\n`;
         currentCategory = cat;
       }
-      output += `${settings.prefix}${c.help.name}${" ".repeat(longest - c.help.name.length)} :: ${c.help.description}\n`;
+      output += `${message.settings.prefix}${c.help.name}${" ".repeat(longest - c.help.name.length)} :: ${c.help.description}\n`;
     });
     message.channel.send(output, {code: "asciidoc", split: { char: "\u200b" }});
   } else {

--- a/commands/help.js
+++ b/commands/help.js
@@ -10,7 +10,7 @@ exports.run = (client, message, args, level) => {
   // If no specific command is called, show all filtered commands.
   if (!args[0]) {
     // Load guild settings (for prefixes and eventually per-guild tweaks)
-    const settings = message.guild ? client.settings.get(message.guild.id) : client.config.defaultSettings;
+    const settings = client.getGuildSettings(message);
 
     // Filter all commands by which are available for the user's level, using the <Collection>.filter() method.
     const myCommands = message.guild ? client.commands.filter(cmd => client.levelCache[cmd.conf.permLevel] <= level) : client.commands.filter(cmd => client.levelCache[cmd.conf.permLevel] <= level &&  cmd.conf.guildOnly !== true);

--- a/commands/set.js
+++ b/commands/set.js
@@ -14,50 +14,46 @@ const { inspect } = require("util");
 // const [action, key, ...value] = args;
 exports.run = async (client, message, [action, key, ...value], level) => { // eslint-disable-line no-unused-vars
 
-  // Retrieve current guild settings
-  const settings = client.getGuildSettings(message);
+  // Retrieve current guild settings (merged) and overrides only.
+  const settings = message.settings;
+  const overrides = client.settings.get(message.guild.id);
   
-  // First, if a user does `-set add <key> <new value>`, let's add it
-  if (action === "add") {
-    if (!key) return message.reply("Please specify a key to add");
-    if (settings[key]) return message.reply("This key already exists in the settings");
-    if (value.length < 1) return message.reply("Please specify a value");
-
-    // `value` being an array, we need to join it first.
-    settings[key] = value.join(" ");
-  
-    // One the settings is modified, we write it back to the collection
-    client.settings.set(message.guild.id, settings);
-    message.reply(`${key} successfully added with the value of ${value.join(" ")}`);
-  } else
-  
-  // Secondly, if a user does `-set edit <key> <new value>`, let's change it
+  // Edit an existing key value
   if (action === "edit") {
+    // User must specify a key.
     if (!key) return message.reply("Please specify a key to edit");
+    // User must specify a key that actually exists!
     if (!settings[key]) return message.reply("This key does not exist in the settings");
+    // User must specify a value to change.
     if (value.length < 1) return message.reply("Please specify a new value");
-  
-    settings[key] = value.join(" ");
+    // User must specify a different value than the current one.
+    if (value.join(" ") === settings[key]) return message.reply("This setting already has that value!");
+    
+    // If the guild does not have any overrides, initialize it.
+    if (!client.settings.has(message.guild.id)) client.settings.set(message.guild.id, {});
 
-    client.settings.set(message.guild.id, settings);
+    // setProp is an enmap feature, it defines a single property of an object in an enmap key/value pair.
+    client.settings.setProp(message.guild.id, key, value.join(" "));
+
+    // Confirm everything is fine!
     message.reply(`${key} successfully edited to ${value.join(" ")}`);
   } else
   
-  // Thirdly, if a user does `-set del <key>`, let's ask the user if they're sure...
-  if (action === "del") {
-    if (!key) return message.reply("Please specify a key to delete.");
+  // Resets a key to the default value
+  if (action === "reset") {
+    if (!key) return message.reply("Please specify a key to reset.");
     if (!settings[key]) return message.reply("This key does not exist in the settings");
+    if (!overrides[key]) return message.reply("This key does not have an override and is already using defaults.");
     
-    // Throw the 'are you sure?' text at them.
-    const response = await client.awaitReply(message, `Are you sure you want to permanently delete ${key}? This **CANNOT** be undone.`);
+    // Good demonstration of the custom awaitReply method in `./modules/functions.js` !
+    const response = await client.awaitReply(message, `Are you sure you want to reset ${key} to the default value?`);
 
     // If they respond with y or yes, continue.
-    if (["y", "yes"].includes(response)) {
-
+    if (["y", "yes"].includes(response.toLowerCase())) {
       // We delete the `key` here.
-      delete settings[key];
-      client.settings.set(message.guild.id, settings);
-      message.reply(`${key} was successfully deleted.`);
+      delete overrides[key];
+      client.settings.set(message.guild.id, overrides);
+      message.reply(`${key} was successfully reset.`);
     } else
     // If they respond with n or no, we inform them that the action has been cancelled.
     if (["n","no","cancel"].includes(response)) {
@@ -68,7 +64,8 @@ exports.run = async (client, message, [action, key, ...value], level) => { // es
   if (action === "get") {
     if (!key) return message.reply("Please specify a key to view");
     if (!settings[key]) return message.reply("This key does not exist in the settings");
-    message.reply(`The value of ${key} is currently ${settings[key]}`);
+    const isDefault = !overrides[key] ? "\nThis is the default global default value." : "";
+    message.reply(`The value of ${key} is currently ${settings[key]}${isDefault}`);
   } else {
     message.channel.send(inspect(settings), {code: "json"});
   }

--- a/commands/set.js
+++ b/commands/set.js
@@ -15,7 +15,7 @@ const { inspect } = require("util");
 exports.run = async (client, message, [action, key, ...value], level) => { // eslint-disable-line no-unused-vars
 
   // Retrieve current guild settings
-  const settings = client.settings.get(message.guild.id);
+  const settings = client.getGuildSettings(message);
   
   // First, if a user does `-set add <key> <new value>`, let's add it
   if (action === "add") {

--- a/events/guildCreate.js
+++ b/events/guildCreate.js
@@ -1,6 +1,5 @@
 // This event executes when a new guild (server) is joined.
 
 module.exports = (client, guild) => {
-  // We need to add this guild to our settings!
-  client.settings.set(guild.id, client.config.defaultSettings);
+  client.logger.cmd(`[GUILD JOIN] ${guild.name} (${guild.id}) added the bot. Owner: ${guild.owner.user.tag} (${guild.owner.user.id})`);
 };

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,6 +1,11 @@
 // This event executes when a new guild (server) is left.
 
 module.exports = (client, guild) => {
-  // Well they're gone. Let's remove them from the settings!
-  client.settings.delete(guild.id);
+  client.logger.cmd(`[GUILD LEAVE] ${guild.name} (${guild.id}) removed the bot.`);
+
+  // If the settings Enmap contains any guild overrides, remove them.
+  // No use keeping stale data!
+  if (client.settings.has(guild.id)) {
+    client.settings.delete(guild.id);
+  }
 };

--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -2,7 +2,7 @@
 
 module.exports = (client, member) => {
   // Load the guild's settings
-  const settings = client.settings.get(member.guild.id);
+  const settings = client.getGuildSettings(member.guild);
 
   // If welcome is off, don't proceed (don't welcome the user)
   if (settings.welcomeEnabled !== "true") return;

--- a/events/message.js
+++ b/events/message.js
@@ -7,15 +7,9 @@ module.exports = (client, message) => {
   // and not get into a spam loop (we call that "botception").
   if (message.author.bot) return;
 
-  // Grab the settings for this server from the PersistentCollection
+  // Grab the settings for this server from Enmap.
   // If there is no guild, get default conf (DMs)
-  const settings = message.guild
-    ? client.settings.get(message.guild.id)
-    : client.config.defaultSettings;
-
-  // For ease of use in commands and functions, we'll attach the settings
-  // to the message object, so `message.settings` is accessible.
-  message.settings = settings;
+  const settings = message.settings = client.getGuildSettings(message);
 
   // Also good practice to ignore any message that does not start with our prefix,
   // which is set in the configuration file.

--- a/events/message.js
+++ b/events/message.js
@@ -9,7 +9,7 @@ module.exports = (client, message) => {
 
   // Grab the settings for this server from Enmap.
   // If there is no guild, get default conf (DMs)
-  const settings = message.settings = client.getGuildSettings(message);
+  const settings = message.settings = client.getGuildSettings(message.guild);
 
   // Also good practice to ignore any message that does not start with our prefix,
   // which is set in the configuration file.

--- a/events/ready.js
+++ b/events/ready.js
@@ -4,9 +4,10 @@ module.exports = async client => {
   // for all of them to be loaded.
   await client.wait(1000);
 
-  // Both `wait` and `client.log` are in `./modules/functions`.
   client.logger.log(`[READY] ${client.user.tag}, ready to serve ${client.users.size} users in ${client.guilds.size} servers.`, "ready");
 
-  // We check for any guilds added while the bot was offline, if any were, they get a default configuration.
-  client.guilds.filter(g => !client.settings.has(g.id)).forEach(g => client.settings.set(g.id, client.config.defaultSettings));
+  // Both `wait` and `client.log` are in `./modules/functions`.
+
+  // Make the bot "play the game" which is the help command with default prefix.
+  client.user.setActivity(`${client.config.defaultSettings.prefix}help`, {type: "PLAYING"});
 };

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,12 +1,6 @@
 module.exports = async client => {
-  // Why await here? Because the ready event isn't actually ready, sometimes
-  // guild information will come in *after* ready. 1s is plenty, generally,
-  // for all of them to be loaded.
-  await client.wait(1000);
-
+  // Log that the bot is online.
   client.logger.log(`[READY] ${client.user.tag}, ready to serve ${client.users.size} users in ${client.guilds.size} servers.`, "ready");
-
-  // Both `wait` and `client.log` are in `./modules/functions`.
 
   // Make the bot "play the game" which is the help command with default prefix.
   client.user.setActivity(`${client.config.defaultSettings.prefix}help`, {type: "PLAYING"});

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const Discord = require("discord.js");
 // We also load the rest of the things we need in this file:
 const { promisify } = require("util");
 const readdir = promisify(require("fs").readdir);
-const Enmap = require("enmap");
+const Enmap = require("../enmap");
 const EnmapLevel = require("enmap-level");
 
 // This is your client. Some people call it `bot`, some people call it `self`,

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const Discord = require("discord.js");
 // We also load the rest of the things we need in this file:
 const { promisify } = require("util");
 const readdir = promisify(require("fs").readdir);
-const Enmap = require("../enmap");
+const Enmap = require("enmap");
 const EnmapLevel = require("enmap-level");
 
 // This is your client. Some people call it `bot`, some people call it `self`,

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -26,6 +26,24 @@ module.exports = (client) => {
   };
 
   /*
+  GUILD SETTINGS FUNCTION
+
+  This function merges the default settings (from config.defaultSettings) with any
+  guild override you might have for particular guild. If no overrides are present,
+  the default settings are used.
+
+  */
+  client.getGuildSettings = message => {
+    const def = client.config.defaultSettings;
+    if (!message.guild) return def;
+    const overrides = client.settings.get(message.guild.id) || {};
+    for (const key in def) {
+      overrides[key] = overrides[key] || def[key];
+    }
+    return overrides;
+  };
+
+  /*
   SINGLE-LINE AWAITMESSAGE
 
   A simple way to grab a single reply, from the user that initiated

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -33,14 +33,15 @@ module.exports = (client) => {
   the default settings are used.
 
   */
-  client.getGuildSettings = message => {
+  client.getGuildSettings = (guild) => {
     const def = client.config.defaultSettings;
-    if (!message.guild) return def;
-    const overrides = client.settings.get(message.guild.id) || {};
+    if (!guild) return def;
+    const returns = {};
+    const overrides = client.settings.get(guild.id) || {};
     for (const key in def) {
-      overrides[key] = overrides[key] || def[key];
+      returns[key] = overrides[key] || def[key];
     }
-    return overrides;
+    return returns;
   };
 
   /*
@@ -79,7 +80,7 @@ module.exports = (client) => {
     if (text && text.constructor.name == "Promise")
       text = await text;
     if (typeof evaled !== "string")
-      text = require("util").inspect(text, {depth: 0});
+      text = require("util").inspect(text, {depth: 1});
 
     text = text
       .replace(/`/g, "`" + String.fromCharCode(8203))

--- a/package-lock.json
+++ b/package-lock.json
@@ -243,15 +243,15 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "discord.js": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.3.0.tgz",
-      "integrity": "sha512-xM3ydvb4urHjCP3N+Mgpw53a7ZGtmPwllwVgwPqdF2SHNPvTDr4So/+55VVx76s5eO9IMrOWpczsEuIr0/MAgQ==",
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.3.2.tgz",
+      "integrity": "sha512-Abw9CTMX3Jb47IeRffqx2VNSnXl/OsTdQzhvbw/JnqCyqc2imAocc7pX2HoRmgKd8CgSqsjBFBneusz/E16e6A==",
       "requires": {
-        "long": "3.2.0",
-        "prism-media": "0.0.1",
-        "snekfetch": "3.6.1",
+        "long": "4.0.0",
+        "prism-media": "0.0.2",
+        "snekfetch": "3.6.4",
         "tweetnacl": "1.0.0",
-        "ws": "4.0.0"
+        "ws": "4.1.0"
       }
     },
     "duplexer2": {
@@ -596,9 +596,9 @@
       }
     },
     "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "minimist": {
       "version": "1.2.0",
@@ -626,9 +626,9 @@
       "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "moment-duration-format": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz",
-      "integrity": "sha1-VBdxtfh6BJzGVUBHXTrZZnN9aQg="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.2.2.tgz",
+      "integrity": "sha1-uVdhLeJgFsmtnrYIfAVFc+USd3k="
     },
     "multileveldown": {
       "version": "2.3.0",
@@ -744,9 +744,9 @@
       }
     },
     "prism-media": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.1.tgz",
-      "integrity": "sha1-o0JcnKvVDRxsAuVDlBoRiVZnvRA="
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.2.tgz",
+      "integrity": "sha512-L6yc8P5NVG35ivzvfI7bcTYzqFV+K8gTfX9YaJbmIFfMXTs71RMnAupvTQPTCteGsiOy9QcNLkQyWjAafY/hCQ=="
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -869,9 +869,9 @@
       }
     },
     "snekfetch": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.1.tgz",
-      "integrity": "sha512-aLEvf1YR440pINb0LEo/SL2Q2s/A26+YEqPlx09A0XpGH7qWp8iqIFFolVILHn2yudWXJne9QWyQu+lzDp+ksQ=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
+      "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw=="
     },
     "source-map": {
       "version": "0.1.43",
@@ -1127,11 +1127,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
-    "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
-    },
     "unzip-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
@@ -1161,13 +1156,12 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
-      "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "requires": {
         "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,17 @@
   "requires": true,
   "dependencies": {
     "abstract-leveldown": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+      "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
       "requires": {
         "xtend": "4.0.1"
       }
     },
-    "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "optional": true
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -47,36 +41,7 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
+        "readable-stream": "2.3.5"
       }
     },
     "async-limiter": {
@@ -84,63 +49,45 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
-    "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-    },
-    "bl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+    "babel-polyfill": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.4",
+        "regenerator-runtime": "0.10.5"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.4",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
     },
-    "brfs": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.3.tgz",
-      "integrity": "sha1-22ddb16SPm3wh/ylhZyQkKrtMhY=",
-      "requires": {
-        "quote-stream": "1.0.2",
-        "resolve": "1.4.0",
-        "static-module": "1.5.0",
-        "through2": "2.0.3"
-      }
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
-    "buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "requires": {
+        "readable-stream": "2.3.5",
+        "safe-buffer": "5.1.1"
+      }
     },
     "chalk": {
       "version": "2.3.0",
@@ -152,10 +99,28 @@
         "supports-color": "4.5.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
     "chownr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -175,54 +140,28 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
+    "core-js": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -230,17 +169,22 @@
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "deferred-leveldown": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
+      "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
       "requires": {
-        "abstract-leveldown": "2.6.3"
+        "abstract-leveldown": "4.0.3"
       }
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "discord.js": {
       "version": "11.3.2",
@@ -254,88 +198,51 @@
         "ws": "4.1.0"
       }
     },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "iconv-lite": "0.4.19"
       }
     },
-    "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+    "encoding-down": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.0.tgz",
+      "integrity": "sha512-jyhdwd61FJEXJQk9KaaUIXXoe6Uix15lBGY/pBv1qEqFgOuzSwgREeb0eaP7ZdA7C3rNFBhs6Fj/RifNkLCaFw==",
       "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
+        "abstract-leveldown": "4.0.3",
+        "level-codec": "8.0.0",
+        "level-errors": "1.1.2"
       }
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "1.4.0"
       }
     },
     "enmap": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/enmap/-/enmap-0.4.2.tgz",
-      "integrity": "sha512-KRe9X9ZMr2loFuFBgPs0hFe/8yogXytYMw0E0ZFtGwTN8/qTV6fwKfN3WrywVkAU606D4bkIyMVJvoD4oA/lEQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/enmap/-/enmap-2.0.4.tgz",
+      "integrity": "sha512-9Z/O1GLLyVsq1FBWzkzDWWAEJVyIjqDBNl1nWAADMs3nfOeS5WUPWFJunQ8N96Z3kpi2BPf1LzG2/1OZKVPVHg=="
     },
     "enmap-level": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/enmap-level/-/enmap-level-1.0.0.tgz",
-      "integrity": "sha512-13IwpzF6DaUmRkb20r+Ssx3l+Qrv+ocqWiL4C3qOdDjdmnuYGgPqrng1YipC/0ug9iBHfqlH+KPfstHlvUbsMQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/enmap-level/-/enmap-level-2.0.2.tgz",
+      "integrity": "sha512-la/8DE12CRTX8R0dLAeYKPdiKjDfwg+6oysUAiyfjcJdFepuc/cMrXjHNcnQQockA0GLf90GlCMrprUxQFkGNA==",
       "requires": {
-        "native-level-promise": "0.1.0"
+        "level": "3.0.0"
       }
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "0.0.0"
-      },
-      "dependencies": {
-        "prr": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-        }
+        "prr": "1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -343,46 +250,19 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "escodegen": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
-      "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
-      "requires": {
-        "esprima": "1.1.1",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
-      }
-    },
-    "esprima": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
-      "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk="
-    },
-    "estraverse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-      "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
-    },
-    "esutils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-      "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
-    },
     "expand-template": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
       "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
     },
-    "falafel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
-      "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
-        "acorn": "5.1.2",
-        "foreach": "2.0.5",
-        "isarray": "0.0.1",
-        "object-keys": "1.0.11"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
       }
     },
     "fast-future": {
@@ -390,15 +270,13 @@
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
       "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -415,30 +293,17 @@
         "wide-align": "1.1.2"
       }
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
-    "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "function-bind": "1.1.1"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -451,15 +316,93 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "inquirer": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+      "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "chalk": "1.1.3",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx": "4.1.0",
+        "string-width": "2.1.1",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -469,136 +412,105 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "length-prefixed-stream": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-1.5.1.tgz",
-      "integrity": "sha1-mer1FnLd3vv92Ige57e33zXR7XM=",
-      "requires": {
-        "readable-stream": "2.3.3",
-        "varint": "5.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "level": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
-      "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-3.0.0.tgz",
+      "integrity": "sha512-jIMBmvh/u0hagHWN+Ysbrom3Tx2Ck3V5lxcLgGnOSgq7ASGvqYq+dJVwOO62fU3P04jDSdienlRwdb+RUvhzkw==",
       "requires": {
-        "level-packager": "1.2.1",
-        "leveldown": "1.7.2"
+        "level-packager": "2.1.1",
+        "leveldown": "3.0.0",
+        "opencollective": "1.0.3"
       }
     },
     "level-codec": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz",
+      "integrity": "sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q=="
     },
     "level-errors": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+      "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
       "requires": {
-        "errno": "0.1.4"
+        "errno": "0.1.7"
       }
     },
     "level-iterator-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.0.tgz",
+      "integrity": "sha512-TWOYw8HR5mhj6xwoVLo0yu26RPL6v28KgvhK1kY1CJf9LyL+rJXjx99zhORTYhN9ysOBIH+iaxAiqRteA+C1/g==",
       "requires": {
         "inherits": "2.0.3",
-        "level-errors": "1.0.5",
-        "readable-stream": "1.1.14",
+        "readable-stream": "2.3.5",
         "xtend": "4.0.1"
       }
     },
     "level-packager": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-      "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
+      "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
       "requires": {
-        "levelup": "1.3.9"
-      }
-    },
-    "level-party": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/level-party/-/level-party-3.0.4.tgz",
-      "integrity": "sha1-gCB6y9nBi5zaSYJTjViGhAQbT8w=",
-      "requires": {
-        "has": "1.0.1",
-        "level": "1.7.0",
-        "multileveldown": "2.3.0",
-        "pump": "1.0.2"
+        "encoding-down": "4.0.0",
+        "levelup": "2.0.2"
       }
     },
     "leveldown": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
-      "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.0.tgz",
+      "integrity": "sha512-CA2mRUDTgVscTDOCvHSgYvksqj1VW7g3ss2idWfITSB7l201ahQJ81cwLTupW76idbjpx7zmmmpdttYnnHWWtA==",
       "requires": {
-        "abstract-leveldown": "2.6.3",
-        "bindings": "1.2.1",
+        "abstract-leveldown": "4.0.3",
+        "bindings": "1.3.0",
         "fast-future": "1.0.2",
-        "nan": "2.6.2",
-        "prebuild-install": "2.3.0"
+        "nan": "2.8.0",
+        "prebuild-install": "2.5.1"
       }
     },
     "levelup": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
+      "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
       "requires": {
-        "deferred-leveldown": "1.2.2",
-        "level-codec": "7.0.1",
-        "level-errors": "1.0.5",
-        "level-iterator-stream": "1.3.1",
-        "prr": "1.0.1",
-        "semver": "5.4.1",
+        "deferred-leveldown": "3.0.0",
+        "level-errors": "1.1.2",
+        "level-iterator-stream": "2.0.0",
         "xtend": "4.0.1"
       }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
     },
     "minimist": {
       "version": "1.2.0",
@@ -630,38 +542,32 @@
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.2.2.tgz",
       "integrity": "sha1-uVdhLeJgFsmtnrYIfAVFc+USd3k="
     },
-    "multileveldown": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/multileveldown/-/multileveldown-2.3.0.tgz",
-      "integrity": "sha1-iCDIgaJ+nB7+yt4VTj+36P4GByI=",
-      "requires": {
-        "abstract-leveldown": "2.6.3",
-        "brfs": "1.4.3",
-        "duplexify": "3.5.1",
-        "end-of-stream": "1.4.0",
-        "length-prefixed-stream": "1.5.1",
-        "levelup": "1.3.9",
-        "numeric-id-map": "1.1.0",
-        "protocol-buffers": "3.2.1"
-      }
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-    },
-    "native-level-promise": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/native-level-promise/-/native-level-promise-0.1.0.tgz",
-      "integrity": "sha512-UwmEKEMe+wVjvkCYDBkJ+y61MRGPUTHYwFUFCynZW+WCEdYe4LHL+WCg8EX13raDWrxmBg6LY9aKM7luVvzsYQ==",
-      "requires": {
-        "level-party": "3.0.4"
-      }
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "node-abi": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-      "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.3.0.tgz",
+      "integrity": "sha512-zwm6vU3SsVgw3e9fu48JBaRBCJGIvAgysDsqtf5+vEexFE71bEOtaMWb5zr/zODZNzTPtQlqUUpC79k68Hspow==",
+      "requires": {
+        "semver": "5.5.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -684,25 +590,10 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
-    "numeric-id-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/numeric-id-map/-/numeric-id-map-1.1.0.tgz",
-      "integrity": "sha1-ERDkRFrmg+g9R56t0PbZJJ/aO9Y="
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-inspect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
-      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
-    },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "once": {
       "version": "1.4.0",
@@ -712,35 +603,103 @@
         "wrappy": "1.0.2"
       }
     },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "opencollective": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+      "requires": {
+        "babel-polyfill": "6.23.0",
+        "chalk": "1.1.3",
+        "inquirer": "3.0.6",
+        "minimist": "1.2.0",
+        "node-fetch": "1.6.3",
+        "opn": "4.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
+    "opn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "prebuild-install": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
-      "integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.1.tgz",
+      "integrity": "sha512-3DX9L6pzwc1m1ksMkW3Ky2WLgPQUBiySOfXVl3WZyAeJSyJb4wtoH9OmeRGcubAWsMlLiL8BTHbwfm/jPQE9Ag==",
       "requires": {
+        "detect-libc": "1.0.3",
         "expand-template": "1.1.0",
         "github-from-package": "0.0.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "node-abi": "2.1.1",
+        "node-abi": "2.3.0",
         "noop-logger": "0.1.1",
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
-        "pump": "1.0.2",
-        "rc": "1.2.1",
-        "simple-get": "1.4.3",
+        "pump": "2.0.1",
+        "rc": "1.2.6",
+        "simple-get": "2.7.0",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
-        "xtend": "4.0.1"
+        "which-pm-runs": "1.0.0"
       }
     },
     "prism-media": {
@@ -749,27 +708,9 @@
       "integrity": "sha512-L6yc8P5NVG35ivzvfI7bcTYzqFV+K8gTfX9YaJbmIFfMXTs71RMnAupvTQPTCteGsiOy9QcNLkQyWjAafY/hCQ=="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "protocol-buffers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/protocol-buffers/-/protocol-buffers-3.2.1.tgz",
-      "integrity": "sha1-NyWOF+JKCC8G67F3MekoUdHHaIk=",
-      "requires": {
-        "brfs": "1.4.3",
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "protocol-buffers-schema": "3.3.2",
-        "signed-varint": "2.0.1",
-        "varint": "5.0.0"
-      }
-    },
-    "protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "prr": {
       "version": "1.0.1",
@@ -777,53 +718,65 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pump": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "once": "1.4.0"
       }
     },
-    "quote-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
-      "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
-      "requires": {
-        "buffer-equal": "0.0.1",
-        "minimist": "1.2.0",
-        "through2": "2.0.3"
-      }
-    },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       }
     },
     "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
-    "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "path-parse": "1.0.5"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -831,158 +784,39 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "shallow-copy": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
-    "signed-varint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
-      "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
-      "requires": {
-        "varint": "5.0.0"
-      }
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "simple-get": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
+      "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
       "requires": {
+        "decompress-response": "3.3.0",
         "once": "1.4.0",
-        "unzip-response": "1.0.2",
-        "xtend": "4.0.1"
+        "simple-concat": "1.0.0"
       }
     },
     "snekfetch": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
       "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw=="
-    },
-    "source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-      "optional": true,
-      "requires": {
-        "amdefine": "1.0.1"
-      }
-    },
-    "static-eval": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
-      "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
-      "requires": {
-        "escodegen": "0.0.28"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "0.0.28",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
-          "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
-          "requires": {
-            "esprima": "1.0.4",
-            "estraverse": "1.3.2",
-            "source-map": "0.1.43"
-          }
-        },
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-        },
-        "estraverse": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
-          "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
-        }
-      }
-    },
-    "static-module": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
-      "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
-      "requires": {
-        "concat-stream": "1.6.0",
-        "duplexer2": "0.0.2",
-        "escodegen": "1.3.3",
-        "falafel": "2.1.0",
-        "has": "1.0.1",
-        "object-inspect": "0.4.0",
-        "quote-stream": "0.0.0",
-        "readable-stream": "1.0.34",
-        "shallow-copy": "0.0.1",
-        "static-eval": "0.2.4",
-        "through2": "0.4.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "quote-stream": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
-          "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
-          "requires": {
-            "minimist": "0.0.8",
-            "through2": "0.4.2"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "0.4.0"
-          }
-        }
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "string-width": {
       "version": "1.0.2",
@@ -995,9 +829,12 @@
       }
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -1027,86 +864,43 @@
       "requires": {
         "chownr": "1.0.1",
         "mkdirp": "0.5.1",
-        "pump": "1.0.2",
-        "tar-stream": "1.5.4"
+        "pump": "1.0.3",
+        "tar-stream": "1.5.5"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
       }
     },
     "tar-stream": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
+        "bl": "1.2.2",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.5",
         "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
-    "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
+        "os-tmpdir": "1.0.2"
       }
     },
     "tunnel-agent": {
@@ -1122,25 +916,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
       "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "varint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/An-Idiots-Guide/guidebot#readme",
   "dependencies": {
     "chalk": "^2.3.0",
-    "discord.js": "^11.3.0",
+    "discord.js": "^11.3.2",
     "enmap": "^0.4.2",
     "enmap-level": "^1.0.0",
     "moment": "^2.20.1",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "discord.js": "^11.3.2",
-    "enmap": "^0.4.2",
-    "enmap-level": "^1.0.0",
+    "enmap": "^2.0.4",
+    "enmap-level": "^2.0.2",
     "moment": "^2.20.1",
     "moment-duration-format": "^2.2.0"
   }


### PR DESCRIPTION
This PR modifies the following: 
- Update discord.js to 11.3.1
- Update Enmap to 2.0.4
- Update enmap-level to 2.0.2
- Introduce `client.getGuildSettings` in the functions file to merge the defaultSettings with specific per-guild overrides
- Modify the `set` command to only use overrides
- Modify the `help` command to properly use the new getGuildSettings method
- Modify the `message` event to properly use the new getGuildSettings method
- Modify the `guildMemberAdd`, `guildCreate` and `guildDelete` methods to use the new settings methodology. Also added guild join/part messages while I'm at it.
- Modify the `ready` event to not insert guild settings that are unnecessary.

**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
