### PR TITLE
Fix minor typo in a comment

### DIFF
--- a/modules/functions.js
+++ b/modules/functions.js
@@ -123,7 +123,7 @@ module.exports = (client) => {
     return false;
   };
 
-  /* MISCELANEOUS NON-CRITICAL FUNCTIONS */
+  /* MISCELLANEOUS NON-CRITICAL FUNCTIONS */
   
   // EXTENDING NATIVE TYPES IS BAD PRACTICE. Why? Because if JavaScript adds this
   // later, this conflicts with native code. Also, if some other lib you use does


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
I noticed a typo ("miscelaneous" instead of "miscellaneous"), and typos bug me, so this is a fix for it.

**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to README, etc.
