### PR TITLE
reloading commands with their alias

### DIFF
--- a/commands/reload.js
+++ b/commands/reload.js
@@ -1,13 +1,13 @@
 exports.run = async (client, message, args, level) => {// eslint-disable-line no-unused-vars
   if (!args || args.length < 1) return message.reply("Must provide a command to reload. Derp.");
-
+  const command = client.commands.get(args[0]) || client.commands.get(client.aliases.get(args[0]));
   let response = await client.unloadCommand(args[0]);
   if (response) return message.reply(`Error Unloading: ${response}`);
 
   response = client.loadCommand(args[0]);
   if (response) return message.reply(`Error Loading: ${response}`);
-
-  message.reply(`The command \`${args[0]}\` has been reloaded`);
+ 
+  message.reply(`The command \`${command.help.name}\` has been reloaded`);
 };
 
 exports.conf = {

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -91,8 +91,7 @@ module.exports = (client) => {
   };
 
   client.loadCommand = (commandName) => {
-    if (client.aliases.has(commandName))
-        commandName = client.aliases.get(commandName);
+    if (client.aliases.has(commandName)) commandName = client.aliases.get(commandName);
     try {
       client.logger.log(`Loading Command: ${commandName}`);
       const props = require(`../commands/${commandName}`);

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -109,14 +109,9 @@ module.exports = (client) => {
   };
 
   client.unloadCommand = async (commandName) => {
-    let command;
-    if (client.commands.has(commandName)) {
-      command = client.commands.get(commandName);
-    } else if (client.aliases.has(commandName)) {
-      command = client.commands.get(client.aliases.get(commandName));
-      commandName = client.aliases.get(commandName);
-    }
-    if (!command) return `The command \`${commandName}\` doesn"t seem to exist, nor is it an alias. Try again!`;
+    const command = client.commands.get(commandName) || client.commands.get(client.aliases.get(commandName));
+    commandName = command.help.name;
+    if (!command) return `The command \`${commandName}\` doesn't seem to exist, nor is it an alias. Try again!`;
   
     if (command.shutdown) {
       await command.shutdown(client);

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -91,6 +91,8 @@ module.exports = (client) => {
   };
 
   client.loadCommand = (commandName) => {
+    if (client.aliases.has(commandName))
+        commandName = client.aliases.get(commandName);
     try {
       client.logger.log(`Loading Command: ${commandName}`);
       const props = require(`../commands/${commandName}`);
@@ -113,6 +115,7 @@ module.exports = (client) => {
       command = client.commands.get(commandName);
     } else if (client.aliases.has(commandName)) {
       command = client.commands.get(client.aliases.get(commandName));
+      commandName = client.aliases.get(commandName);
     }
     if (!command) return `The command \`${commandName}\` doesn"t seem to exist, nor is it an alias. Try again!`;
   

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -110,8 +110,8 @@ module.exports = (client) => {
 
   client.unloadCommand = async (commandName) => {
     const command = client.commands.get(commandName) || client.commands.get(client.aliases.get(commandName));
-    commandName = command.help.name;
     if (!command) return `The command \`${commandName}\` doesn't seem to exist, nor is it an alias. Try again!`;
+    commandName = command.help.name;
   
     if (command.shutdown) {
       await command.shutdown(client);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
allowing reloading of commands with their alias
credits to omer#0001 for locating and fixing the error before I pulled my fork
**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
