### PR TITLE
Stop throwing errors when a command is ran in DM

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -3,7 +3,7 @@
 // goes `client, other, args` when this function is run.
 
 module.exports = async (client, message) => {
-  const config = require('../config.js');
+  const config = require("../config.js");
   // It's good practice to ignore other bots. This also makes your bot ignore itself
   // and not get into a spam loop (we call that "botception").
   if (message.author.bot) return;

--- a/events/message.js
+++ b/events/message.js
@@ -3,13 +3,18 @@
 // goes `client, other, args` when this function is run.
 
 module.exports = async (client, message) => {
+  const config = require('../config.js');
   // It's good practice to ignore other bots. This also makes your bot ignore itself
   // and not get into a spam loop (we call that "botception").
   if (message.author.bot) return;
 
   // Grab the settings for this server from Enmap.
   // If there is no guild, get default conf (DMs)
-  const settings = message.settings = client.getSettings(message.guild.id);
+  if (message.guild) {
+    let settings = message.settings = client.getSettings(message.guild.id);
+  } else {
+    settings = config.defaultSettings;
+  }
 
   // Checks if the bot was mentioned, with no message after it, returns the prefix.
   const prefixMention = new RegExp(`^<@!?${client.user.id}>( |)$`);


### PR DESCRIPTION
Made it so if there is a guild, get the guild's settings, otherwise, use the default settings.

**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**

Before, this code would throw 'Cannot read property ID of null'. Before:
![image](https://user-images.githubusercontent.com/41408947/51950116-067ece00-23e4-11e9-99ba-2c53dac5c974.png)
After:
![image](https://user-images.githubusercontent.com/41408947/51950134-14345380-23e4-11e9-80d6-e0cd45be12fe.png)
In DMs:
![image](https://user-images.githubusercontent.com/41408947/51950200-56f62b80-23e4-11e9-98d9-8052a39a1deb.png)


**Semantic versioning classification:**  
- [ * ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
