### PR TITLE
Added an ensure to client.getSettings to make sure default exists

### DIFF
--- a/modules/functions.js
+++ b/modules/functions.js
@@ -37,6 +37,7 @@ module.exports = (client) => {
   // getSettings merges the client defaults with the guild settings. guild settings in
   // enmap should only have *unique* overrides that are different from defaults.
   client.getSettings = (guild) => {
+    client.settings.ensure('default', client.config.defaultSettings)
     if(!guild) return client.settings.get("default");
     const guildConf = client.settings.get(guild.id) || {};
     // This "..." thing is the "Spread Operator". It's awesome!


### PR DESCRIPTION


**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**

I don't have any proof on hand but my bot had issues due to not having pictures but on my bot, it works and the error was due to "default" being undefined. 

**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
note:
This should fix #81. It fixed an issue with dm's erroring and using the set command. Alternatively client.settings.set could be used or you could put `client.settings.set('default', client.config.defaultSettings)` in the ready event as well to apply changes to the default.