### PR TITLE
changing misleading exit code and unloading commands before shutting down

### DIFF
--- a/commands/reboot.js
+++ b/commands/reboot.js
@@ -1,8 +1,8 @@
-exports.run = async (client, message, args, level) => {// eslint-disable-line no-unused-vars
+exports.run = async (client, message, args, level) => { // eslint-disable-line no-unused-vars
   await message.reply("Bot is shutting down.");
-  client.commands.forEach( async cmd => {
-    await client.unloadCommand(cmd);
-  });
+  await Promise.all(client.commands.map(cmd =>
+    client.unloadCommand(cmd)
+  ));
   process.exit(1);
 };
 

--- a/commands/reboot.js
+++ b/commands/reboot.js
@@ -3,7 +3,7 @@ exports.run = async (client, message, args, level) => { // eslint-disable-line n
   await Promise.all(client.commands.map(cmd =>
     client.unloadCommand(cmd)
   ));
-  process.exit(1);
+  process.exit(0);
 };
 
 exports.conf = {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
The Process is shutting down with a misleading exit code, and in most cases, the process would shut down before all commands could be reloaded because of the usage of forEach.

**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
