### PR TITLE
allowing reloading via alias.

### DIFF
--- a/commands/reload.js
+++ b/commands/reload.js
@@ -1,13 +1,13 @@
-exports.run = async (client, message, args, level) => {// eslint-disable-line no-unused-vars
+exports.run = async (client, message, args, level) => { // eslint-disable-line no-unused-vars
   if (!args || args.length < 1) return message.reply("Must provide a command to reload. Derp.");
-
+  const command = client.commands.get(args[0]) || client.commands.get(client.aliases.get(args[0]));
   let response = await client.unloadCommand(args[0]);
   if (response) return message.reply(`Error Unloading: ${response}`);
 
-  response = client.loadCommand(args[0]);
+  response = client.loadCommand(command.help.name);
   if (response) return message.reply(`Error Loading: ${response}`);
 
-  message.reply(`The command \`${args[0]}\` has been reloaded`);
+  message.reply(`The command \`${command.help.name}\` has been reloaded`);
 };
 
 exports.conf = {

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -130,13 +130,12 @@ module.exports = (client) => {
       command = client.commands.get(client.aliases.get(commandName));
     }
     if (!command) return `The command \`${commandName}\` doesn"t seem to exist, nor is it an alias. Try again!`;
-    commandName = command.help.name;
     
     if (command.shutdown) {
       await command.shutdown(client);
     }
-    const mod = require.cache[require.resolve(`../commands/${commandName}`)];
-    delete require.cache[require.resolve(`../commands/${commandName}.js`)];
+    const mod = require.cache[require.resolve(`../commands/${command.help.name}`)];
+    delete require.cache[require.resolve(`../commands/${command.help.name}.js`)];
     for (let i = 0; i < mod.parent.children.length; i++) {
       if (mod.parent.children[i] === mod) {
         mod.parent.children.splice(i, 1);

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -130,7 +130,8 @@ module.exports = (client) => {
       command = client.commands.get(client.aliases.get(commandName));
     }
     if (!command) return `The command \`${commandName}\` doesn"t seem to exist, nor is it an alias. Try again!`;
-  
+    commandName = command.help.name;
+    
     if (command.shutdown) {
       await command.shutdown(client);
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
#### "reopening" this pr after I closed #70
Its not possible to reload commands with their alias, even tho, the Bot says so.
This PR should fix that.
## New Version:
image removed
## Old Version:
image removed

**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
