### PR TITLE
Fixed User Avatar URLs (Dashboard)

### DIFF
--- a/dashboard/templates/blocks/header.ejs
+++ b/dashboard/templates/blocks/header.ejs
@@ -44,7 +44,7 @@
           <% if(user) { %>
             <li class="nav-item dropdown">
               <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="userDropdown" >
-                <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>.png?size=32" width="25" height="25" class="d-inline-block align-middle rounded-circle" alt="">
+                <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>?size=32" width="25" height="25" class="d-inline-block align-middle rounded-circle" alt="">
                 <%= user.username %>#<%= user.discriminator %>
               </a>
               <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">

--- a/dashboard/templates/blocks/header.ejs
+++ b/dashboard/templates/blocks/header.ejs
@@ -44,7 +44,7 @@
           <% if(user) { %>
             <li class="nav-item dropdown">
               <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="userDropdown" >
-                <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>?size=32" width="25" height="25" class="d-inline-block align-middle rounded-circle" alt="">
+                <img src="<%= user.avatarURL %>?size=32" width="25" height="25" class="d-inline-block align-middle rounded-circle" alt="">
                 <%= user.username %>#<%= user.discriminator %>
               </a>
               <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">


### PR DESCRIPTION
Removed the `.png` from the URL. Not needed and it broke default avatars and made gif avatars still. 

**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
I tested with a png, gif and default avatar. It works. Don't believe me then try it yourself

**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
