### PR TITLE
Log eval output to console if longer than message limit

### DIFF
--- a/commands/eval.js
+++ b/commands/eval.js
@@ -11,7 +11,12 @@ exports.run = async (client, message, args, level) => { // eslint-disable-line n
   try {
     const evaled = eval(code);
     const clean = await client.clean(client, evaled);
-    message.channel.send(`\`\`\`js\n${clean}\n\`\`\``);
+    if (clean.length > 1090) { 
+      client.logger.debug(clean);
+      message.channel.send("```\nResponse too long. Check the console for full output.\n```");
+    } else {
+      message.channel.send(`\`\`\`js\n${clean}\n\`\`\``);
+    }
   } catch (err) {
     message.channel.send(`\`ERROR\` \`\`\`xl\n${await client.clean(client, err)}\n\`\`\``);
   }


### PR DESCRIPTION
Possible solution for #92 

**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
If the output of the eval command is within the Discord message limit, the output is sent to chat as normal. If it is longer than the Discord message limit (1090 to account for Markdown) the output is logged to the console and a message is displayed notifying the user.

![image](https://user-images.githubusercontent.com/11392691/72498103-5d033900-37fc-11ea-8800-4ddc9965a93f.png)


**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
