### PR TITLE
Check if the command is not enabled

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -40,6 +40,12 @@ module.exports = async (client, message) => {
   // using this const varName = thing OR otherthign; is a pretty efficient
   // and clean way to grab one of 2 values!
   if (!cmd) return;
+  
+  //A command might be not enabled. This message informs the command invoker that the command is disabled.
+
+  if (cmd && !cmd.conf.enabled) {
+    return message.channel.send("Sorry, this command is disabled. Please wait until the bot owner enables the command.");
+  }
 
   // Some commands may not be useable in DMs. This check prevents those commands from running
   // and return a friendly error message.


### PR DESCRIPTION
Added a check that checks if cmd.conf.enabled is false.
This will prevent user from executing a command that is disabled.

**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**

Added a check that verifies if `cmd.conf.enabled` is false.

**Semantic versioning classification:**  
- [x] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
