### PR TITLE
Check for outage on the guildDelete event.

### DIFF
--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,7 +1,7 @@
 // This event executes when a new guild (server) is left.
 
 module.exports = (client, guild) => {
-  if (!guild.available) return; // Check for an outage.
+  if (!guild.available) return; // if there is an outage, return.
   
   client.logger.cmd(`[GUILD LEAVE] ${guild.name} (${guild.id}) removed the bot.`);
 

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,7 +1,7 @@
 // This event executes when a new guild (server) is left.
 
 module.exports = (client, guild) => {
-  if (!guild.available) return; // If there is an outage, return.
+   if (!guild.available) return; // If there is an outage, return.
   
   client.logger.cmd(`[GUILD LEAVE] ${guild.name} (${guild.id}) removed the bot.`);
 

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,7 +1,7 @@
 // This event executes when a new guild (server) is left.
 
 module.exports = (client, guild) => {
-  if (!guild.available) return; // if there is an outage, return.
+  if (!guild.available) return; // If there is an outage, return.
   
   client.logger.cmd(`[GUILD LEAVE] ${guild.name} (${guild.id}) removed the bot.`);
 

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,6 +1,8 @@
 // This event executes when a new guild (server) is left.
 
 module.exports = (client, guild) => {
+  if (!guild.available) return; // Check for an outage.
+  
   client.logger.cmd(`[GUILD LEAVE] ${guild.name} (${guild.id}) removed the bot.`);
 
   // If the settings Enmap contains any guild overrides, remove them.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**

This pull request should be merged because when there is an outage, the guildDelete event fires. That means the bot could remove the guild from db even tho they didn’t remove the bot.

**Semantic versioning classification:**  
- [x] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
