### PR TITLE
Updated intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,18 @@ You also need your bot's token. This is obtained by creating an application in
 the [Developer section](https://discord.com/developers) of discord.com. Check the [first section of this page](https://anidiots.guide/getting-started/the-long-version.html) 
 for more info.
 
-Guidebot uses intents which are required as of October 7, 2020. By default we use `Intents.All`, however this has privileged intents. You can enable this in the bot page 
+# Intents
+
+Guidebot uses intents which are required as of October 7, 2020. 
+You can enable privileged intents in your bot page 
 (the one you got your token from) under `Privileged Gateway Intents`.
 
-If you don't want to enable privileged intents you can change the client from 
-```js
-const client = new Discord.Client({ ws: { intents: Discord.Intents.ALL } });
-```
-to 
-```js
-const client = new Discord.Client({ ws: { intents: Discord.Intents.NON_PRIVILEGED } });
-``` 
-in your index.js. 
+By default GuideBot needs Guilds, Guild Messages and Direct Messages to work.
+For join messages to work you need Guild Members, which is privileged.
+User counts that GuideBot has in places such as in the ready log, and the stats 
+command may be incorrect without the Guild Members intent.
 
-**WARNING: Changing this will disable welcome messages!**
+Intents are loaded from your config, and will get created by the setup scripts.
 
 For more info about intents checkout the [official Discord.js guide page](https://discordjs.guide/popular-topics/intents.html) and the [official Discord docs page](https://discord.com/developers/docs/topics/gateway#gateway-intents).
 ## Downloading

--- a/config.js.example
+++ b/config.js.example
@@ -11,6 +11,12 @@ const config = {
   // Your Bot's Token. Available on https://discord.com/developers/applications/me
   "token": "mfa.VkO_2G4Qv3T--NO--lWetW_tjND--TOKEN--QFTm6YGtzq9PH--4U--tG0",
 
+  // Intents the bot needs.
+  // By default GuideBot needs Guilds, Guild Messages and Direct Messages to work.
+  // For join messages to work you need Guild Members, which is privileged and requires extra setup.
+  // For more info about intents see the README.
+  intents: ["GUILDS","GUILD_MESSAGES","DIRECT_MESSAGES"],
+
   // Default per-server settings. New guilds have these settings. 
 
   // DO NOT LEAVE ANY OF THESE BLANK, AS YOU WILL NOT BE ABLE TO UPDATE THEM

--- a/config_base.txt
+++ b/config_base.txt
@@ -11,6 +11,12 @@ const config = {
   // Your Bot's Token. Available on https://discord.com/developers/applications/me
   "token": {{token}},
 
+  // Intents the bot needs.
+  // By default GuideBot needs Guilds, Guild Messages and Direct Messages to work.
+  // For join messages to work you need Guild Members, which is privileged and requires extra setup.
+  // For more info about intents see the README.
+  intents: {{intents}},
+
   // PERMISSION LEVEL DEFINITIONS.
   permLevels: [
     // This is the lowest permisison level, this is for non-roled users.

--- a/index.js
+++ b/index.js
@@ -9,14 +9,19 @@ const Discord = require("discord.js");
 const { promisify } = require("util");
 const readdir = promisify(require("fs").readdir);
 const Enmap = require("enmap");
+const config = require("./config.js");
 
 // This is your client. Some people call it `bot`, some people call it `self`,
 // some might call it `cootchie`. Either way, when you see `client.something`,
 // or `bot.something`, this is what we're referring to. Your client.
-const client = new Discord.Client();
+const client = new Discord.Client({
+  ws: {
+    intents: config.intents
+  }
+});
 
 // Here we load the config file that contains our token and our prefix values.
-client.config = require("./config.js");
+client.config = config
 // client.config.token contains the bot's token
 // client.config.prefix contains the message prefix
 

--- a/setup.js
+++ b/setup.js
@@ -39,6 +39,31 @@ let prompts = [
     name: "ownerID",
     message: "Please enter the bot owner's User ID"
   },
+  {
+    type: "checkbox",
+    name: "intents",
+    message: "Which intents would you like? \n" +
+      "By default GuideBot needs Guilds, Guild Messages and Direct Messages to work. \n" +
+      "For join messages to work you need Guild Members, which is privileged and requires extra setup.\n" +
+      "For more info about intents see the README.",
+    choices: [
+      { "name": "Guilds", "value": "GUILDS", "checked": true },
+      { "name": "Guild Messages", "value": "GUILD_MESSAGES", "checked": true },
+      { "name": "Direct Messages", "value": "DIRECT_MESSAGES", "checked": true },
+      { "name": "Guild Bans", "value": "GUILD_BANS" },
+      { "name": "Guild Emojis", "value": "GUILD_EMOJIS" },
+      { "name": "Guild Integrations", "value": "GUILD_INTEGRATIONS" },
+      { "name": "Guild Webhooks", "value": "GUILD_WEBHOOKS" },
+      { "name": "Guild Invites", "value": "GUILD_INVITES" },
+      { "name": "Guild Voice States", "value": "GUILD_VOICE_STATES" },
+      { "name": "Guild Message Reactions", "value": "GUILD_MESSAGE_REACTIONS" },
+      { "name": "Guild Message Typing", "value": "GUILD_MESSAGE_TYPING" },
+      { "name": "Direct Message Reactions", "value": "DIRECT_MESSAGE_REACTIONS" },
+      { "name": "Direct Message Typing", "value": "DIRECT_MESSAGE_TYPING" },
+      { "name": "Guild Presences (privileged)", "value": "GUILD_PRESENCES" },
+      { "name": "Guild Members (privileged)", "value": "GUILD_MEMBERS" },
+    ]
+  },
 ];
 
 (async function () {
@@ -59,7 +84,8 @@ let prompts = [
 
   baseConfig = baseConfig
     .replace("{{ownerID}}", answers.ownerID)
-    .replace("{{token}}", `"${answers.token}"`);
+    .replace("{{token}}", `"${answers.token}"`)
+    .replace("{{intents}}", JSON.stringify(answers.intents));
 
   fs.writeFileSync("./config.js", baseConfig);
   console.log("REMEMBER TO NEVER SHARE YOUR TOKEN WITH ANYONE!");


### PR DESCRIPTION
This change makes GuideBot work out of the box properly with intents.

Before you needed to enable privileged intents to use the bot. Now the setup script will ask for intents and give you info on privileged intents.
![The Setup Script](https://cdn.discordapp.com/attachments/267727088465739778/758347409691639888/unknown.png).
They have also been updated in the example config.
The readme has also been updated to explain this.

**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
