### PR TITLE
Updates eslint configuration to work with latest eslint and fixes one whitespace error this creates.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2020
   },
   "env": {
     "es6": true,

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -52,7 +52,7 @@ module.exports = (client) => {
   // enmap should only have *unique* overrides that are different from defaults.
   client.getSettings = (guild) => {
     client.settings.ensure("default", defaultSettings);
-    if(!guild) return client.settings.get("default");
+    if (!guild) return client.settings.get("default");
     const guildConf = client.settings.get(guild.id) || {};
     // This "..." thing is the "Spread Operator". It's awesome!
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax


### PR DESCRIPTION
Title sums it up, tiniest pull request ever.  Wow.  Such portfolio material.

It should be merged so that when dumb newbies like me who have installed the latest eslint globally clone this project, they don't encounter an [error](https://i.imgur.com/8664DRu.png) and end up having to search to the 2347237th page of google to find [this post](https://github.com/eslint/eslint/issues/10307) in order to figure out what's wrong, due to their pathetic googlefu technique.

You know, I'm something of a contributor myself.