### PR TITLE
chore: use Intents.FLAGS instead of string intents

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -1,3 +1,5 @@
+const { Intents } = require("discord.js");
+
 const config = {
   // Bot Admins, level 9 by default. Array of user ID strings.
   "admins": [],
@@ -12,7 +14,7 @@ const config = {
   // By default GuideBot needs Guilds, Guild Messages and Direct Messages to work.
   // For join messages to work you need Guild Members, which is privileged and requires extra setup.
   // For more info about intents see the README.
-  intents: ["GUILDS", "GUILD_MESSAGES", "DIRECT_MESSAGES"],
+  intents: [ Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.DIRECT_MESSAGES ],
   // Partials your bot may need should go here, CHANNEL is required for DM's
   partials: ["CHANNEL"],
 


### PR DESCRIPTION
This pr removes the string intents in `config.js.example` and replaces them with `Intents.FLAGS` intents which are safer and preferred.
