### PR TITLE
Fixed Issues in Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Need support? Join the [Idiot's Guide Community](https://discord.gg/vXVxsAjSMF)!
 - The node-gyp build tools. This is a pre-requisite for Enmap, but also for a **lot** of other modules. See [The Enmap Guide](https://enmap.evie.codes/install#pre-requisites) for details and requirements for your OS. Just follow what's in the tabbed block only, then come back here!
 
 You also need your bot's token. This is obtained by creating an application in
-the Developer section of discord.com. Check the [first section of this page](https://anidiots.guide/getting-started/the-long-version.html)
+the Developer section of discord.com. Check the [first section of this page](https://anidiots.guide/getting-started/getting-started-long-version)
 for more info.
 
 ## Intents

--- a/commands/reboot.js
+++ b/commands/reboot.js
@@ -3,9 +3,12 @@ const { settings } = require("../modules/settings.js");
 exports.run = async (client, message, args, level) => { // eslint-disable-line no-unused-vars
   const replying = settings.ensure(message.guild.id, config.defaultSettings).commandReply;
   await message.reply({ content: "Bot is shutting down.", allowedMentions: { repliedUser: (replying === "true") }});
-  await Promise.all(client.container.commands.map(cmd =>
-    client.unloadCommand(cmd)
-  ));
+  await Promise.all(client.container.commands.map(cmd => {
+    // the path is relative to the *current folder*, so just ./filename.js
+    delete require.cache[require.resolve(`./${cmd.help.name}.js`)];
+    // We also need to delete and reload the command from the container.commands Enmap
+    client.container.commands.delete(cmd.help.name);
+  }));
   process.exit(0);
 };
 

--- a/commands/reload.js
+++ b/commands/reload.js
@@ -7,7 +7,7 @@ exports.run = async (client, message, args, level) => { // eslint-disable-line n
   if (!args || args.length < 1) return message.reply("Must provide a command name to reload.");
   const command = container.commands.get(args[0]) || container.commands.get(container.aliases.get(args[0]));
   // Check if the command exists and is valid
-  if (!container.commands.has(command.help.name)) {
+  if (!command) {
     return message.reply("That command does not exist");
   }
   // the path is relative to the *current folder*, so just ./filename.js

--- a/commands/set.js
+++ b/commands/set.js
@@ -33,13 +33,13 @@ exports.run = async (client, message, [action, key, ...value], level) => { // es
     // User must specify a value to change.
     if (joinedValue.length < 1) return message.reply({ content: "Please specify a new value", allowedMentions: { repliedUser: (replying === "true") }});
     // User must specify a different value than the current one.
-    if (joinedValue === settings[key]) return message.reply({ content: "This setting already has that value!", allowedMentions: { repliedUser: (replying === "true") }});
+    if (joinedValue === serverSettings[key]) return message.reply({ content: "This setting already has that value!", allowedMentions: { repliedUser: (replying === "true") }});
     
     // If the guild does not have any overrides, initialize it.
-    if (!client.settings.has(message.guild.id)) client.settings.set(message.guild.id, {});
+    if (!settings.has(message.guild.id)) settings.set(message.guild.id, {});
 
     // Modify the guild overrides directly.
-    client.settings.set(message.guild.id, joinedValue, key);
+    settings.set(message.guild.id, joinedValue, key);
 
     // Confirm everything is fine!
     message.reply({ content: `${key} successfully edited to ${joinedValue}`, allowedMentions: { repliedUser: (replying === "true") }});
@@ -57,12 +57,12 @@ exports.run = async (client, message, [action, key, ...value], level) => { // es
     // If they respond with y or yes, continue.
     if (["y", "yes"].includes(response.toLowerCase())) {
       // We delete the `key` here.
-      client.settings.delete(message.guild.id, key);
+      settings.delete(message.guild.id, key);
       message.reply({ content: `${key} was successfully reset to default.`, allowedMentions: { repliedUser: (replying === "true") }});
     } else
     // If they respond with n or no, we inform them that the action has been cancelled.
     if (["n","no","cancel"].includes(response)) {
-      message.reply({ content: `Your setting for \`${key}\` remains at \`${settings[key]}\``, allowedMentions: { repliedUser: (replying === "true") }});
+      message.reply({ content: `Your setting for \`${key}\` remains at \`${serverSettings[key]}\``, allowedMentions: { repliedUser: (replying === "true") }});
     }
   } else
   
@@ -70,7 +70,7 @@ exports.run = async (client, message, [action, key, ...value], level) => { // es
     if (!key) return message.reply({ content: "Please specify a key to view", allowedMentions: { repliedUser: (replying === "true") }});
     if (!defaults[key]) return message.reply({ content: "This key does not exist in the settings", allowedMentions: { repliedUser: (replying === "true") }});
     const isDefault = !overrides[key] ? "\nThis is the default global default value." : "";
-    message.reply({ content: `The value of ${key} is currently ${settings[key]}${isDefault}`, allowedMentions: { repliedUser: (replying === "true") }});
+    message.reply({ content: `The value of ${key} is currently ${serverSettings[key]}${isDefault}`, allowedMentions: { repliedUser: (replying === "true") }});
   } else {
     // Otherwise, the default action is to return the whole configuration;
     const array = [];

--- a/commands/stats.js
+++ b/commands/stats.js
@@ -8,7 +8,7 @@ exports.run = (client, message, args, level) => { // eslint-disable-line no-unus
   const stats = codeBlock("asciidoc", `= STATISTICS =
   • Mem Usage  :: ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2)} MB
   • Uptime     :: ${duration}
-  • Users      :: ${client.users.cache.size.toLocaleString()}
+  • Users      :: ${client.guilds.cache.map(g => g.memberCount).reduce((a, b) => a + b).toLocaleString()}
   • Servers    :: ${client.guilds.cache.size.toLocaleString()}
   • Channels   :: ${client.channels.cache.size.toLocaleString()}
   • Discord.js :: v${version}

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -17,6 +17,10 @@ module.exports = async (client, interaction) => {
       interaction.followUp({ content: `There was a problem with your request.\n\`\`\`${e.message}\`\`\``, ephemeral: true })
         .catch(e => console.error("An error occurred following up on an error", e));
     else 
+    if (interaction.deferred)
+      interaction.editReply({ content: `There was a problem with your request.\n\`\`\`${e.message}\`\`\``, ephemeral: true })
+        .catch(e => console.error("An error occurred following up on an error", e));
+    else 
       interaction.reply({ content: `There was a problem with your request.\n\`\`\`${e.message}\`\`\``, ephemeral: true })
         .catch(e => console.error("An error occurred replying on an error", e));
   }

--- a/events/ready.js
+++ b/events/ready.js
@@ -2,7 +2,7 @@ const logger = require("../modules/Logger.js");
 const { getSettings } = require("../modules/functions.js");
 module.exports = async client => {
   // Log that the bot is online.
-  logger.log(`${client.user.tag}, ready to serve ${client.users.cache.size} users in ${client.guilds.cache.size} servers.`, "ready");
+  logger.log(`${client.user.tag}, ready to serve ${client.guilds.cache.map(g => g.memberCount).reduce((a, b) => a + b)} users in ${client.guilds.cache.size} servers.`, "ready");
   
   // Make the bot "play the game" which is the help command with default prefix.
   client.user.setActivity(`${getSettings("default").prefix}help`, { type: "PLAYING" });

--- a/slash/leave.js
+++ b/slash/leave.js
@@ -1,5 +1,9 @@
+const { Permissions } = require('discord.js');
+
 exports.run = async (client, interaction) => { // eslint-disable-line no-unused-vars
   await interaction.deferReply();
+  if(!interaction.guild.me.permissions.has(Permissions.FLAGS.KICK_MEMBERS)) 
+    return await interaction.editReply("I do not have permission to kick members in this server.");
   await interaction.member.send("You requested to leave the server, if you change your mind you can rejoin at a later date.");
   await interaction.member.kick(`${interaction.member.displayName} wanted to leave.`);
   await interaction.editReply(`${interaction.member.displayName} left in a hurry!`);

--- a/slash/stats.js
+++ b/slash/stats.js
@@ -8,7 +8,7 @@ exports.run = async (client, interaction) => { // eslint-disable-line no-unused-
   const stats = codeBlock("asciidoc", `= STATISTICS =
 • Mem Usage  :: ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2)} MB
 • Uptime     :: ${duration}
-• Users      :: ${client.users.cache.size.toLocaleString()}
+• Users      :: ${client.guilds.cache.map(g => g.memberCount).reduce((a, b) => a + b).toLocaleString()}
 • Servers    :: ${client.guilds.cache.size.toLocaleString()}
 • Channels   :: ${client.channels.cache.size.toLocaleString()}
 • Discord.js :: v${version}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
* [README](https://github.com/Fierythunder/guidebot/blob/simplification/README.md) - Fixed broken link
* Commands
     * [Reboot command](https://github.com/Fierythunder/guidebot/blob/simplification/commands/reboot.js) throws error `client.unloadCommand is not a function`
     * [Reload command](https://github.com/Fierythunder/guidebot/blob/simplification/commands/reload.js) - if command is not found then command.help throughs undefined error
     * [Set command](https://github.com/Fierythunder/guidebot/blob/simplification/commands/set.js) - renamed variables `settings[key]` with `serverSettings[key]`, `client.settings` with `settings`
     * [Stats command](https://github.com/Fierythunder/guidebot/blob/simplification/commands/stats.js) shows incorrect users size replaced it with [code sent by](https://discord.com/channels/260202843686830080/865201217575452702/885405538928713748) by @WilsontheWolf
 * Events
     * [interactionCreate](https://github.com/Fierythunder/guidebot/blob/simplification/events/interactionCreate.js) - interaction.deferred prevents the commands from breaking
     * [ready](https://github.com/Fierythunder/guidebot/blob/simplification/events/ready.js) - shows incorrect users size replaced it with [code sent by](https://discord.com/channels/260202843686830080/865201217575452702/885405538928713748) by @WilsontheWolf
* Slash Commands
    * [Leave command](https://github.com/Fierythunder/guidebot/blob/simplification/slash/leave.js) - throughs permission error when kick permissions are not enabled
     * [Stats command](https://github.com/Fierythunder/guidebot/blob/simplification/slash/stats.js) shows incorrect users size replaced it with [code sent by](https://discord.com/channels/260202843686830080/865201217575452702/885405538928713748) by @WilsontheWolf


**Semantic versioning classification:**

- [x] This PR changes the framework's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
