### PR TITLE
removed token lines from config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-config.json
-config.js
 data/
 test.js
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+config.json
+config.js
 data/
 test.js
 

--- a/config.js.example
+++ b/config.js.example
@@ -7,9 +7,6 @@ const config = {
   // Bot Support, level 8 by default. Array of user ID strings
   "support": [],
 
-  // Your Bot's Token. Available on https://discord.com/developers/applications/me
-  "token": "Replace me",
-
   // Intents the bot needs.
   // By default GuideBot needs Guilds, Guild Messages and Direct Messages to work.
   // For join messages to work you need Guild Members, which is privileged and requires extra setup.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
Token is now present in `.env` so there is no need of having these lines for token in config.js
```
  // Your Bot's Token. Available on https://discord.com/developers/applications/me
  "token": "Replace me",
```
So, no need of hiding config.js in git ignore

**Semantic versioning classification:**

- [x] This PR changes the framework's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
